### PR TITLE
Cmake headers install fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(
 
 install(TARGETS WideDecimal EXPORT WideDecimalTargets)
 install(
-  FILES math/wide_decimal/decwide_t.h math/wide_decimal/decwide_t_detail.h math/wide_decimal/decwide_t_fft.h math/wide_decimal/decwide_t_namespace.h math/wide_decimal/decwide_t_default_ops.h
+  FILES math/wide_decimal/decwide_t.h math/wide_decimal/decwide_t_detail.h math/wide_decimal/decwide_t_detail_fft.h math/wide_decimal/decwide_t_detail_namespace.h math/wide_decimal/decwide_t_detail_ops.h
   DESTINATION include/math/wide_decimal/)
 install(EXPORT WideDecimalTargets
   FILE WideDecimalConfig.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,42 @@ target_include_directories(
   $<INSTALL_INTERFACE:include>)
 
 install(TARGETS WideDecimal EXPORT WideDecimalTargets)
+
 install(
-  FILES math/wide_decimal/decwide_t.h math/wide_decimal/decwide_t_detail.h math/wide_decimal/decwide_t_detail_fft.h math/wide_decimal/decwide_t_detail_namespace.h math/wide_decimal/decwide_t_detail_ops.h
+  FILES math/wide_decimal/decwide_t.h math/wide_decimal/decwide_t_detail.h
+    math/wide_decimal/decwide_t_detail_fft.h math/wide_decimal/decwide_t_detail_namespace.h
+    math/wide_decimal/decwide_t_detail_ops.h
   DESTINATION include/math/wide_decimal/)
+
+install(
+  FILES math/constants/constants_pi_control_for_decwide_t.h
+DESTINATION include/math/constants/)
+
+install(
+  FILES mcal_lcd/mcal_lcd_console.h mcal_lcd/mcal_lcd_base.h mcal_lcd/mcal_lcd_generic_st7066.h
+DESTINATION include/mcal_lcd/)
+
+install(
+  FILES util/utility/util_baselexical_cast.h util/utility/util_dynamic_array.h
+    util/utility/util_noncopyable.h
+  DESTINATION include/util/utility/
+)
+
+install(
+  FILES util/memory/util_n_slot_array_allocator.h
+  DESTINATION include/util/memory/
+)
+
+install(
+  FILES util/stdcpp/stdcpp_patch.cpp
+  DESTINATION include/util/stdcpp/
+)
+
+install(
+  FILES boost/math/bindings/decwide_t.hpp
+  DESTINATION include/boost/math/bindings/
+)
+
 install(EXPORT WideDecimalTargets
   FILE WideDecimalConfig.cmake
   NAMESPACE WideDecimal::


### PR DESCRIPTION
Hi! Thanks For this Lib.

The actual install target don't include all necessary 
headers files. this PR fix this.

Without this PR I dont able to use wide-integer.
just a simple test:
mkdir BUILD
cd BUILD
cmake ..
make
make install
cd ..
mkdir test_install_create
cd test_install_create

create file create_test.cpp:
#include <iomanip>
#include <iostream>

#include <math/wide_decimal/decwide_t.h>

void do_something()
{
  using dec101_t = math::wide_decimal::decwide_t<INT32_C(101), std::uint32_t, void>;

  dec101_t d = dec101_t(1) / 3;

  // 0.33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333
  std::cout << std::setprecision(std::numeric_limits<dec101_t>::digits) << d << std::endl;
}
'save file'
g++ -std=c++20 create_test.cpp
this will fail.

more elaborate src files failed because more missing cascate headers files. this PR sane this.

Thanks for this lib, I really love It :-)

Best Wishes,
Gratefull Dani.



