### PR TITLE
Refactor ldbl conv

### DIFF
--- a/.github/workflows/wide_decimal.yml
+++ b/.github/workflows/wide_decimal.yml
@@ -470,39 +470,6 @@ jobs:
           ${{ matrix.compiler }} -finline-functions -m64 -O3 -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wunused-parameter -Wuninitialized -Wunreachable-code -Winit-self -Wzero-as-null-pointer-constant -std=${{ matrix.standard }} -I. -I../boost-root -pthread -lpthread test/test.cpp test/test_decwide_t_algebra.cpp test/test_decwide_t_algebra_edge.cpp test/test_decwide_t_examples.cpp examples/example000a_multiply_pi_squared.cpp examples/example000_multiply_nines.cpp examples/example001_roots_sqrt.cpp examples/example001a_roots_seventh.cpp examples/example001b_roots_almost_integer.cpp examples/example001c_roots_sqrt_limb08.cpp examples/example001d_pow2_from_list.cpp examples/example002_pi.cpp examples/example002a_pi_small_limb.cpp examples/example002b_pi_100k.cpp examples/example002c_pi_quintic.cpp examples/example002d_pi_limb08.cpp examples/example003_zeta.cpp examples/example004_bessel_recur.cpp examples/example005_polylog_series.cpp examples/example006_logarithm.cpp examples/example007_catalan_series.cpp examples/example008_bernoulli_tgamma.cpp examples/example009_boost_math_standalone.cpp examples/example009a_boost_math_standalone.cpp examples/example009b_boost_math_standalone.cpp examples/example010_hypergeometric_2f1.cpp examples/example010a_hypergeometric_1f1.cpp examples/example011_trig_trapezoid_integral.cpp examples/example012_rational_floor_ceil.cpp examples/example013_embeddable_sqrt.cpp examples/example013a_embeddable_agm.cpp -o wide_decimal.exe
           ls -la ./wide_decimal.exe
           ./wide_decimal.exe
-  gcc-4_bionic:
-    runs-on: ubuntu-18.04
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        standard: [ c++1y ]
-        compiler: [ g++-4.8 ]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - name: clone-submods-bootstrap-headers-boost-develop
-        run: |
-          git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
-          cd ../boost-root
-          git submodule update --init tools
-          git submodule update --init libs/config
-          git submodule update --init libs/math
-          git submodule update --init libs/multiprecision
-          ./bootstrap.sh
-          ./b2 headers
-      - name: update-tools
-        run: sudo apt install gcc-4.8 g++-4.8
-      - name: gcc-4_bionic
-        run: |
-          echo "compile ./wide_decimal.exe"
-          ${{ matrix.compiler }} -v
-          ${{ matrix.compiler }} -finline-functions -fpermissive -m64 -O2 -W -std=${{ matrix.standard }} -I. -I../boost-root -pthread -lpthread test/test.cpp test/test_decwide_t_algebra.cpp test/test_decwide_t_algebra_edge.cpp test/test_decwide_t_examples.cpp examples/example000a_multiply_pi_squared.cpp examples/example000_multiply_nines.cpp examples/example001_roots_sqrt.cpp examples/example001a_roots_seventh.cpp examples/example001b_roots_almost_integer.cpp examples/example001c_roots_sqrt_limb08.cpp examples/example001d_pow2_from_list.cpp examples/example002_pi.cpp examples/example002a_pi_small_limb.cpp examples/example002b_pi_100k.cpp examples/example002c_pi_quintic.cpp examples/example002d_pi_limb08.cpp examples/example003_zeta.cpp examples/example004_bessel_recur.cpp examples/example005_polylog_series.cpp examples/example006_logarithm.cpp examples/example007_catalan_series.cpp examples/example008_bernoulli_tgamma.cpp examples/example009_boost_math_standalone.cpp examples/example009a_boost_math_standalone.cpp examples/example009b_boost_math_standalone.cpp examples/example010_hypergeometric_2f1.cpp examples/example010a_hypergeometric_1f1.cpp examples/example011_trig_trapezoid_integral.cpp examples/example012_rational_floor_ceil.cpp examples/example013_embeddable_sqrt.cpp examples/example013a_embeddable_agm.cpp -o wide_decimal.exe
-          ls -la ./wide_decimal.exe
-          ./wide_decimal.exe
   gcc-clang-10-cpp_dec_float:
     runs-on: ubuntu-20.04
     defaults:

--- a/math/wide_decimal/decwide_t.h
+++ b/math/wide_decimal/decwide_t.h
@@ -36,9 +36,9 @@
   #include <limits>
   #if !defined(WIDE_DECIMAL_DISABLE_IOSTREAM)
   #include <iomanip>
+  #include <ios>
   #include <iostream>
   #else
-  #include <ios>
   #endif
   #include <iterator>
   #if !defined(WIDE_DECIMAL_DISABLE_CONSTRUCT_FROM_STRING)
@@ -747,12 +747,14 @@
     static const initializer my_initializer;
     #endif
 
+    #if !defined(WIDE_DECIMAL_DISABLE_IOSTREAM)
     static auto wr_string(const decwide_t&         x,
                                 std::string&       str, // NOLINT(google-runtime-references)
                                 std::ios::fmtflags ostrm_flags,
                                 std::streamsize    ostrm_precision,
                                 std::streamsize    ostrm_width,
                                 char               ostrm_fill = ' ') -> void; // NOLINT(readability-function-cognitive-complexity,google-runtime-references)
+    #endif
 
   public:
     // Default constructor.
@@ -2297,6 +2299,7 @@
       return x;
     }
 
+    #if !defined(WIDE_DECIMAL_DISABLE_IOSTREAM)
     WIDE_DECIMAL_NODISCARD auto extract_long_double() const -> long double
     {
       // Returns the long double conversion of a decwide_t.
@@ -2339,6 +2342,7 @@
 
       return ldbl_retrieved;
     }
+    #endif
 
     WIDE_DECIMAL_NODISCARD auto extract_signed_long_long() const -> signed long long // NOLINT(google-runtime-int)
     {
@@ -2459,9 +2463,11 @@
       return unsigned_long_long_result;
     }
 
+    #if !defined(WIDE_DECIMAL_DISABLE_IOSTREAM)
     explicit operator long double() const { return                     extract_long_double(); }
     explicit operator double     () const { return static_cast<double>(extract_long_double()); }
     explicit operator float      () const { return static_cast<float> (extract_long_double()); }
+    #endif
 
     template<typename IntegralType,
              typename = typename std::enable_if<std::is_integral<IntegralType>::value>::type>
@@ -4100,13 +4106,14 @@
   template<const std::int32_t ParamDigitsBaseTen, typename LimbType, typename AllocatorType, typename InternalFloatType, typename ExponentType, typename FftFloatType> typename decwide_t<ParamDigitsBaseTen, LimbType, AllocatorType, InternalFloatType, ExponentType, FftFloatType>::representation_type decwide_t<ParamDigitsBaseTen, LimbType, AllocatorType, InternalFloatType, ExponentType, FftFloatType>::my_n_data_for_add_sub;                                                                                                                                                                                                                                                                        // NOLINT(hicpp-uppercase-literal-suffix,readability-uppercase-literal-suffix,cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
   #endif
 
+  #if !defined(WIDE_DECIMAL_DISABLE_IOSTREAM)
   template<const std::int32_t ParamDigitsBaseTen, typename LimbType, typename AllocatorType, typename InternalFloatType, typename ExponentType, typename FftFloatType>
-  auto decwide_t<ParamDigitsBaseTen, LimbType, AllocatorType, InternalFloatType, ExponentType, FftFloatType>::wr_string(const decwide_t&         x,
-                                                                                                                        std::string&       str, // NOLINT(google-runtime-references)
+  auto decwide_t<ParamDigitsBaseTen, LimbType, AllocatorType, InternalFloatType, ExponentType, FftFloatType>::wr_string(const decwide_t&   x,               // NOLINT(readability-function-cognitive-complexity)
+                                                                                                                        std::string&       str,             // NOLINT(google-runtime-references)
                                                                                                                         std::ios::fmtflags ostrm_flags,
-                                                                                                                        std::streamsize    ostrm_precision,
+                                                                                                                        std::streamsize    ostrm_precision, // NOLINT(bugprone-easily-swappable-parameters)
                                                                                                                         std::streamsize    ostrm_width,
-                                                                                                                        char               ostrm_fill) -> void // NOLINT(readability-function-cognitive-complexity,google-runtime-references)
+                                                                                                                        char               ostrm_fill) -> void
   {
     using local_flags_type = std::ios::fmtflags;
 
@@ -4260,6 +4267,7 @@
       str.insert((my_left ? str.end() : str.begin()), static_cast<std::size_t>(n_fill), ostrm_fill);
     }
   }
+  #endif
 
   template<const std::int32_t ParamDigitsBaseTen,
            typename LimbType,


### PR DESCRIPTION
This PR is intended to address #205.

Here we repair and refactor I/O stream round tripping for 10/12-byte long double on GCC-MinGW/Apple x86_64 (which is broken). This is an actual bug fix.

Along the way do some additional long outstanding refactoring.